### PR TITLE
Speed up new shell startup

### DIFF
--- a/bin/avn.sh
+++ b/bin/avn.sh
@@ -84,8 +84,10 @@ function __avn_find_file() {
   echo $found
 }
 
-__avn_chpwd # run chpwd once since the shell was just loaded
-
+# Only run chpwd when the shell loads if there is a .node-version file in the current directory
+if [ -f .node-version ]; then
+  __avn_chpwd # run chpwd once since the shell was just loaded
+fi
 
 ##
 # Hooks that will happen after the working directory is changed


### PR DESCRIPTION
Only run chpwd when the shell loads if there is a `.node-version` file in the current directory.

This speeds up opening a new terminal when the working directory doesn't have a .node-version file.

The hook still runs when you change directories.