### PR TITLE
appendScript to .bashrc for Ubuntu-based

### DIFF
--- a/lib/setup/profile.js
+++ b/lib/setup/profile.js
@@ -91,7 +91,7 @@ module.exports.update = function() {
             if (errLsbRelease) {
               reject();
             }
-            else if (distroId.trim() in { "Ubuntu": null, "LinuxMint": null }) {
+            else if (distroId.trim() in { Ubuntu: null, LinuxMint: null }) {
               resolve();
             }
             else {

--- a/lib/setup/profile.js
+++ b/lib/setup/profile.js
@@ -83,20 +83,24 @@ module.exports.update = function() {
     childProc.exec('uname -s', function(errUname, kernelName) {
       if (errUname) {
         reject();
-      } else if (kernelName.trim() === 'Linux') {
+      }
+      else if (kernelName.trim() === 'Linux') {
 
         childProc.exec('lsb_release -si',
           function(errLsbRelease, distroId) {
             if (errLsbRelease) {
               reject();
-            } else if (distroId.trim() in {'Ubuntu': null, 'LinuxMint': null}) {
+            }
+            else if (distroId.trim() in { "Ubuntu": null, "LinuxMint": null }) {
               resolve();
-            } else {
+            }
+            else {
               reject();
             }
-        });
+          });
 
-      } else {
+      }
+      else {
         reject();
       }
     });
@@ -108,7 +112,8 @@ module.exports.update = function() {
       if (result) {
         handled = true;
         changed = changed || (result === 'change');
-      } else {
+      }
+      else {
         return Promise.resolve('.bashrc');
       }
     });
@@ -121,7 +126,8 @@ module.exports.update = function() {
       if (result) {
         handled = true;
         changed = changed || (result === 'change');
-      } else {
+      }
+      else {
         return Promise.resolve('.bash_profile');
       }
     });

--- a/lib/setup/profile.js
+++ b/lib/setup/profile.js
@@ -80,12 +80,16 @@ module.exports.update = function() {
   var changed = false;
 
   var promise = new Promise(function(resolve, reject) {
-    childProc.exec('uname -s', function(errUname, kernelName, stdErrUname) {
-      if (kernelName.trim() === 'Linux') {
+    childProc.exec('uname -s', function(errUname, kernelName) {
+      if (errUname) {
+        reject();
+      } else if (kernelName.trim() === 'Linux') {
 
         childProc.exec('lsb_release -si',
-          function(errLsbRelease, distroId, stdErrLsbRelease) {
-            if (distroId.trim() in {'Ubuntu': null, 'LinuxMint': null}) {
+          function(errLsbRelease, distroId) {
+            if (errLsbRelease) {
+              reject();
+            } else if (distroId.trim() in {'Ubuntu': null, 'LinuxMint': null}) {
               resolve();
             } else {
               reject();
@@ -98,7 +102,7 @@ module.exports.update = function() {
     });
   })
 
-  .then(function() {  # onResolved
+  .then(function() {  // onResolved
     return appendScript('.bashrc')
     .then(function(result) {
       if (result) {
@@ -109,7 +113,7 @@ module.exports.update = function() {
       }
     });
 
-  }, function() {     # onRejected
+  }, function() {     // onRejected
     Promise.map(['.bash_profile', '.zshrc'], function(name) {
       return appendScript(name);
     })
@@ -120,7 +124,7 @@ module.exports.update = function() {
       } else {
         return Promise.resolve('.bash_profile');
       }
-    })
+    });
   })
 
   .then(function(fileName) {

--- a/lib/setup/profile.js
+++ b/lib/setup/profile.js
@@ -7,6 +7,7 @@ var path = require('path');
 var util = require('util');
 var chalk = require('chalk');
 var isNoEntry = require('../util/codes').isNoEntry;
+var childProc = require('child_process');
 
 /**
  * Generate the string to be included in the shell init script.
@@ -78,19 +79,53 @@ module.exports.update = function() {
   var handled = false;
   var changed = false;
 
-  var promise = Promise.map(['.bash_profile', '.zshrc'], function(name) {
-    return appendScript(name);
-  })
-  .each(function(result) {
-    if (result) {
-      handled = true;
-      changed = changed || (result === 'change');
-    }
-  });
+  var promise = new Promise(function(resolve, reject) {
+    childProc.exec('uname -s', function(errUname, kernelName, stdErrUname) {
+      if (kernelName.trim() === 'Linux') {
 
-  promise = promise.then(function() {
+        childProc.exec('lsb_release -si',
+          function(errLsbRelease, distroId, stdErrLsbRelease) {
+            if (distroId.trim() in {'Ubuntu': null, 'LinuxMint': null}) {
+              resolve();
+            } else {
+              reject();
+            }
+        });
+
+      } else {
+        reject();
+      }
+    });
+  })
+
+  .then(function() {  # onResolved
+    return appendScript('.bashrc')
+    .then(function(result) {
+      if (result) {
+        handled = true;
+        changed = changed || (result === 'change');
+      } else {
+        return Promise.resolve('.bashrc');
+      }
+    });
+
+  }, function() {     # onRejected
+    Promise.map(['.bash_profile', '.zshrc'], function(name) {
+      return appendScript(name);
+    })
+    .each(function(result) {
+      if (result) {
+        handled = true;
+        changed = changed || (result === 'change');
+      } else {
+        return Promise.resolve('.bash_profile');
+      }
+    })
+  })
+
+  .then(function(fileName) {
     if (!handled) {
-      return appendScript('.bash_profile', { force: true });
+      return appendScript(fileName, { force: true });
     }
   })
   .then(function(result) {
@@ -98,12 +133,14 @@ module.exports.update = function() {
       handled = true;
       changed = changed || (result === 'change');
     }
-  });
+  })
 
-  return promise.then(function() {
+  .then(function() {
     if (changed) {
       console.log('%s: %s', chalk.bold.magenta('avn'),
         chalk.bold.cyan('restart your terminal to start using avn'));
     }
   });
+
+  return promise;
 };


### PR DESCRIPTION
This change is due to Ubuntu's preference to use .bashrc for sourcing executables. It works better for me, and I don't need to log out to be able to use avn. I also re-worked the promises, which was necessary for my edit, but most of the original code's untouched, and should still work like before this change.