### PR TITLE
Rework profile.js to use shellInitScriptChooser()

### DIFF
--- a/lib/setup/profile.js
+++ b/lib/setup/profile.js
@@ -66,6 +66,96 @@ var appendScript = function(name, options) {
 };
 
 /**
+ * Chooses the correct shell init script to insert avn initialization string to,
+ * based on the following criteria:
+ * 1. Append to the one that's present, if the other doesn't exist,
+ * 2. If both exist, append to the one that is sourced by the other, or
+ * 3. If both exist, but neither sources the other,
+ *    append to .bashrc if platform is 'linux',
+ *    or append to .bash_profile if platform is 'darwin' (i.e. macOS)
+ *
+ * @private
+ * @function setup.profile.~shellInitScriptChooser
+ * @return {Promise}
+ */
+var shellInitScriptChooser = function() {
+  var bashrcFile = path.join(process.env.HOME, '.bashrc');
+  var bash_profileFile = path.join(process.env.HOME, '.bash_profile');
+  var bashrcExists;
+  var bash_profileExists;
+
+  // Check if .bashrc exists
+  var bashrcPromise = new Promise(function(resolve) {
+    fs.access(bashrcFile, function(err) {
+      bashrcExists = !err;
+      resolve();
+    });
+  });
+
+  // Check if .bash_profile exists
+  var bash_profilePromise = new Promise(function(resolve) {
+    fs.access(bash_profileFile, function(err) {
+      bash_profileExists = !err;
+      resolve();
+    });
+  });
+
+  var promise = Promise.all([bashrcPromise, bash_profilePromise])
+  .then(function() {
+    if (bashrcExists ^ bash_profileExists)  // ^ == bitwise XOR
+      return  (bashrcExists && bashrcFile) ||
+              (bash_profileExists && bash_profileFile);
+
+    if (bashrcExists && bash_profileExists) {
+      var innerPromise = new Promise(function(resolve) {
+        fs.readFile(bash_profileFile, 'utf8', function(err, data) {
+          // RegExp to detect "~/.bashrc",
+          // "$HOME/.bashrc", or "/home/user/.bashrc"
+          var bashrcRe = new RegExp(' ?source +(\\\\\\n)? *(~\/.bashrc|' +
+            "\"?\\$HOME\/.bashrc\"?|[\'\"]?\/home\/\\w+\/.bashrc[\'\"]?)");
+
+          bashrcRe.test(data) ? resolve(bashrcFile) : resolve();
+        });
+      })
+      .then(function(appendFile) {
+        if (appendFile)
+          return appendFile;
+
+        var innerInnerPromise = new Promise(function(resolve) {
+          fs.readFile(bashrcFile, 'utf8', function(err, data) {
+            // RegExp to detect "~/.bash_profile",
+            // "$HOME/.bash_profile", or "/home/user/.bash_profile"
+            var bash_profileRe = new RegExp(' ?source +(\\\\\\n)? *' +
+              "(~\/.bash_profile|\"?\\$HOME\/.bash_profile\"?|" +
+              "[\'\"]?\/home\/\\w+\/.bash_profile[\'\"]?)");
+
+            bash_profileRe.test(data) ? resolve(bash_profileFile) : resolve();
+          });
+        });
+
+        return innerInnerPromise;
+      })
+      .then(function(appendFile) {
+        if (appendFile)
+          return appendFile;
+
+        // Neither .bashrc nor .bash_profile sources the other
+        var platformsToInitScript = {
+          linux:  bashrcFile,
+          darwin: bash_profileFile
+        }
+
+        return platformsToInitScript[process.platform];
+      });
+
+      return innerPromise;
+    }
+  });
+
+  return promise;
+};
+
+/**
  * Update `~/.bash_profile` and `.zshrc` shell profile files.
  *
  * Adds the necessary commands to load `avn.sh` when a new shell is launched.
@@ -77,20 +167,23 @@ var appendScript = function(name, options) {
 module.exports.update = function() {
   var handled = false;
   var changed = false;
+  var appendFile;
 
-  var promise = Promise.map(['.bash_profile', '.zshrc'], function(name) {
-    return appendScript(name);
+  var promise = shellInitScriptChooser()
+  .then(function(initScript) {
+    appendFile = initScript;
+    return appendScript(appendFile);
   })
-  .each(function(result) {
+  .then(function(result) {
     if (result) {
       handled = true;
       changed = changed || (result === 'change');
     }
-  });
+  })
 
-  promise = promise.then(function() {
+  .then(function() {
     if (!handled) {
-      return appendScript('.bash_profile', { force: true });
+      return appendScript(appendFile, { force: true });
     }
   })
   .then(function(result) {
@@ -98,12 +191,14 @@ module.exports.update = function() {
       handled = true;
       changed = changed || (result === 'change');
     }
-  });
+  })
 
-  return promise.then(function() {
+  .then(function() {
     if (changed) {
       console.log('%s: %s', chalk.bold.magenta('avn'),
         chalk.bold.cyan('restart your terminal to start using avn'));
     }
   });
+
+  return promise;
 };


### PR DESCRIPTION
Rework 'avn setup' to use .bashrc or .bash_profile according to the algorithm @wbyoung talked about in #50 