### PR TITLE
Fix compatibility with zsh 5.4.1

### DIFF
--- a/bin/avn.sh
+++ b/bin/avn.sh
@@ -111,7 +111,7 @@ export -a chpwd_functions;
 # https://github.com/mpapis/bash_zsh_support/blob/master/LICENSE
 #
 
-__zsh_like_cd()
+function __zsh_like_cd()
 {
   \typeset __zsh_like_cd_hook
   if
@@ -131,7 +131,7 @@ __zsh_like_cd()
 
 [[ -n "${ZSH_VERSION:-}" ]] ||
 {
-  cd()    { __zsh_like_cd cd    "$@" ; }
-  popd()  { __zsh_like_cd popd  "$@" ; }
-  pushd() { __zsh_like_cd pushd "$@" ; }
+  function cd()    { __zsh_like_cd cd    "$@" ; }
+  function popd()  { __zsh_like_cd popd  "$@" ; }
+  function pushd() { __zsh_like_cd pushd "$@" ; }
 }


### PR DESCRIPTION
Since version 5.4.1, zsh won't allow the definition of functions using the `name()` syntax if `name` is an alias.
In many zsh setups `cd` is probably an alias, causing an error when avn.sh is sourced.

The recommended way to define functions is to always use the `function` keyword, as aliases are not expanded afterwards.

See http://zsh.sourceforge.net/releases.html (5.3.1 to 5.4.1) and http://zsh.sourceforge.net/Doc/Release/Options.html#Scripts-and-Functions for more details.