### PR TITLE
More inclusive regex catching error opening bash_profile

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -371,7 +371,7 @@ describe('avn setup', function() {
         'avn: configuration complete (~/.avnrc)',
         'avn: installation complete',
       ]);
-      expect(std.err).to.match(/^error: EACCES.*, open '[\/\w-]*\/.bash_profile'\n$/);
+      expect(std.err).to.match(/^error: EACCES.*, open '[\/\w-\d\.]*\/.bash_profile'\n$/);
     });
   });
 });


### PR DESCRIPTION
This catches cases where the temporary directory that is created includes digits and the dot character.

Fixes #63 
