### PR TITLE
Read only first line of .node-version

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -72,7 +72,9 @@ exports.chpwd = function(/*dir, [versionFile], [options]*/) {
 
   return Promise.bind({})
   .then(function() { return fs.readFile(path.join(dir, file), 'utf8'); })
-  .then(function(fileContent) { this.version = fileContent.split('\n')[0].trim(); })
+  .then(function(fileContent) {
+    this.version = fileContent.split('\n')[0].trim();
+  })
   .then(function() { return match(this.version); })
   .then(function(result) {
     process.stdout.write(fmt.success(this.version, result, via));

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -72,7 +72,7 @@ exports.chpwd = function(/*dir, [versionFile], [options]*/) {
 
   return Promise.bind({})
   .then(function() { return fs.readFile(path.join(dir, file), 'utf8'); })
-  .then(function(version) { this.version = version.trim(); })
+  .then(function(fileContent) { this.version = fileContent.split('\n')[0].trim(); })
   .then(function() { return match(this.version); })
   .then(function(result) {
     process.stdout.write(fmt.success(this.version, result, via));

--- a/test/fixtures/multiline-version/.node-version
+++ b/test/fixtures/multiline-version/.node-version
@@ -1,0 +1,2 @@
+0.11.13
+# SOME COMMENT

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -80,6 +80,17 @@ describe('avn', function() {
         });
       });
 
+      it('reads only the first line of version file', function() {
+        var std = capture();
+        setupExample('multiline-version');
+        return avn.hooks.chpwd(cwd, '.node-version').finally(std.restore).then(function() {
+          expect(plugin.match).to.have.been.calledWith('0.11.13');
+          expect(std.err).to.be.empty;
+          expect(std.out).to.eql('avn activated 0.11.13 (test v0.11.13)\n');
+          expect(std.cmd).to.eql('node-version-tool activate 0.11.13\n');
+        });
+      });
+
       it('fails if plugin returns undefined', function() {
         var std = capture();
         plugin = { name: 'test', match: function() {} };


### PR DESCRIPTION
Get only the first line of .node-version file content as version.
nvm reads only the first line, so avn should do the same thing.