### PR TITLE
Update regex to handle newer exception message

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -109,7 +109,7 @@ exports.first = function(predicate) {
 rethrowUnlessFailedRequire = function(name, e) {
   var rethrow = true;
   if (e.code === 'MODULE_NOT_FOUND') {
-    var match = e.message.match(/^cannot find module '(.*)'$/i);
+    var match = e.message.match(/^cannot find module '(.*)'/i);
     if (match) { rethrow = (match[1] !== name); }
   }
   if (rethrow) { throw e; }


### PR DESCRIPTION
The exception message has apparently changed in newer version of Node.

Fix for #95.